### PR TITLE
RTSP推流增加L16动态payload type支持(RFC 3551 Section 4.5.11, RFC 2586)

### DIFF
--- a/src/Common/MultiMediaSourceMuxer.cpp
+++ b/src/Common/MultiMediaSourceMuxer.cpp
@@ -361,6 +361,10 @@ bool MultiMediaSourceMuxer::stopSendRtp(MediaSource &sender){
 }
 
 void MultiMediaSourceMuxer::addTrack(const Track::Ptr &track) {
+    if (CodecL16 == track->getCodecId()) {
+        WarnL << "L16音频格式目前只支持RTSP协议推流拉流!!!";
+        return;
+    }
     _muxer->addTrack(track);
 }
 

--- a/src/Extension/Factory.cpp
+++ b/src/Extension/Factory.cpp
@@ -20,6 +20,7 @@
 #include "CommonRtp.h"
 #include "Opus.h"
 #include "G711.h"
+#include "L16.h"
 #include "Common/Parser.h"
 
 namespace mediakit{
@@ -54,6 +55,10 @@ Track::Ptr Factory::getTrackBySdp(const SdpTrack::Ptr &track) {
 
     if (strcasecmp(track->_codec.data(), "PCMU") == 0) {
         return std::make_shared<G711Track>(CodecG711U,  track->_samplerate, track->_channel, 16);
+    }
+
+    if (strcasecmp(track->_codec.data(), "L16") == 0) {
+        return std::make_shared<L16Track>(track->_samplerate, track->_channel);
     }
 
     if (strcasecmp(track->_codec.data(), "h264") == 0) {
@@ -123,6 +128,7 @@ RtpCodec::Ptr Factory::getRtpEncoderBySdp(const Sdp::Ptr &sdp) {
         case CodecH264 : return std::make_shared<H264RtpEncoder>(ssrc, mtu, sample_rate, pt, interleaved);
         case CodecH265 : return std::make_shared<H265RtpEncoder>(ssrc, mtu, sample_rate, pt, interleaved);
         case CodecAAC : return std::make_shared<AACRtpEncoder>(ssrc, mtu, sample_rate, pt, interleaved);
+        case CodecL16 :
         case CodecOpus :
         case CodecG711A :
         case CodecG711U : return std::make_shared<CommonRtpEncoder>(codec_id, ssrc, mtu, sample_rate, pt, interleaved);
@@ -135,6 +141,7 @@ RtpCodec::Ptr Factory::getRtpDecoderByTrack(const Track::Ptr &track) {
         case CodecH264 : return std::make_shared<H264RtpDecoder>();
         case CodecH265 : return std::make_shared<H265RtpDecoder>();
         case CodecAAC : return std::make_shared<AACRtpDecoder>(track->clone());
+        case CodecL16 :
         case CodecOpus :
         case CodecG711A :
         case CodecG711U : return std::make_shared<CommonRtpDecoder>(track->getCodecId());

--- a/src/Extension/Frame.cpp
+++ b/src/Extension/Frame.cpp
@@ -80,6 +80,7 @@ const char *getCodecName(CodecId codecId) {
         SWITCH_CASE(CodecG711A);
         SWITCH_CASE(CodecG711U);
         SWITCH_CASE(CodecOpus);
+        SWITCH_CASE(CodecL16);
         default : return "unknown codec";
     }
 }
@@ -91,7 +92,8 @@ TrackType getTrackType(CodecId codecId){
         case CodecAAC:
         case CodecG711A:
         case CodecG711U:
-        case CodecOpus: return TrackAudio;
+        case CodecOpus: 
+        case CodecL16: return TrackAudio;
         default: return TrackInvalid;
     }
 }

--- a/src/Extension/Frame.h
+++ b/src/Extension/Frame.h
@@ -28,6 +28,7 @@ typedef enum {
     CodecAAC,
     CodecG711A,
     CodecG711U,
+    CodecL16,
     CodecOpus,
     CodecMax = 0x7FFF
 } CodecId;

--- a/src/Extension/Frame.h
+++ b/src/Extension/Frame.h
@@ -28,8 +28,8 @@ typedef enum {
     CodecAAC,
     CodecG711A,
     CodecG711U,
-    CodecL16,
     CodecOpus,
+    CodecL16,
     CodecMax = 0x7FFF
 } CodecId;
 

--- a/src/Extension/L16.cpp
+++ b/src/Extension/L16.cpp
@@ -1,0 +1,26 @@
+﻿/*
+ * Copyright (c) 2016 The ZLMediaKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLMediaKit(https://github.com/xiongziliang/ZLMediaKit).
+ *
+ * Use of this source code is governed by MIT license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "L16.h"
+
+namespace mediakit{
+
+Sdp::Ptr L16Track::getSdp() {
+    WarnL << "Enter  L16Track::getSdp function";
+    if(!ready()){
+        WarnL << getCodecName() << " Track未准备好";
+        return nullptr;
+    }
+    return std::make_shared<L16Sdp>(getCodecId(), getAudioSampleRate(), getAudioChannel(), getBitRate() / 1024);
+}
+
+}//namespace mediakit
+
+

--- a/src/Extension/L16.h
+++ b/src/Extension/L16.h
@@ -1,0 +1,74 @@
+﻿/*
+ * Copyright (c) 2016 The ZLMediaKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLMediaKit(https://github.com/xiongziliang/ZLMediaKit).
+ *
+ * Use of this source code is governed by MIT license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef ZLMEDIAKIT_L16_H
+#define ZLMEDIAKIT_L16_H
+
+#include "Frame.h"
+#include "Track.h"
+
+namespace mediakit{
+
+/**
+ * L16音频通道
+ */
+class L16Track : public AudioTrackImp{
+public:
+    typedef std::shared_ptr<L16Track> Ptr;
+    L16Track(int sample_rate, int channels) : AudioTrackImp(CodecL16,sample_rate,channels,16){}
+
+private:
+    //克隆该Track
+    Track::Ptr clone() override {
+        return std::make_shared<std::remove_reference<decltype(*this)>::type >(*this);
+    }
+    //生成sdp
+    Sdp::Ptr getSdp() override ;
+};
+
+/**
+ * L16类型SDP
+ */
+class L16Sdp : public Sdp {
+public:
+    /**
+     * L16采样位数固定为16位
+     * @param codecId CodecL16
+     * @param sample_rate 音频采样率
+     * @param payload_type rtp payload
+     * @param bitrate 比特率
+     */
+    L16Sdp(CodecId codecId,
+            int sample_rate,
+            int channels,
+            int bitrate = 128,
+            int payload_type = 98) : Sdp(sample_rate,payload_type), _codecId(codecId){
+        _printer << "m=audio 0 RTP/AVP " << payload_type << "\r\n";
+        if (bitrate) {
+            _printer << "b=AS:" << bitrate << "\r\n";
+        }
+        _printer << "a=rtpmap:" << payload_type << " L16/" << sample_rate  << "/" << channels << "\r\n";
+        _printer << "a=control:trackID=" << (int)TrackAudio << "\r\n";
+    }
+
+    string getSdp() const override {
+        return _printer;
+    }
+
+    CodecId getCodecId() const override {
+        return _codecId;
+    }
+private:
+    _StrPrinter _printer;
+    CodecId _codecId;
+};
+
+}//namespace mediakit
+#endif //ZLMEDIAKIT_L16_H


### PR DESCRIPTION
### 添加了L16 PCM数据的RTSP推流支持，目前L16只支持RTSP拉流，其它协议拉流会报错；

### 1. 推流SDP示例：
```
v=0
o=- 0 0 IN IP4 127.0.0.1
c=IN IP4 192.168.3.12
t=0 0
s=Streamed by ZLMediaKit-5.0
a=tool:libavformat 58.45.100
m=audio 0 RTP/AVP 96
b=AS:352
a=rtpmap:96 L16/8000/1
a=control:streamid=0
```

### 2. 拉流FFMPEG命令为：
```
ffplay rtsp://xxx.xxx.xxx.xxx:554/live/test -acodec pcm_s16le -rtsp_transport tcp
```

### 3. 目前存在的问题：
1. UDP拉流10多秒后会断掉，ZLM会出现如下提示，但是TCP拉流不会出现：
```
2020-12-26 15:12:21.606 W MediaServer[22867] RtspSession.cpp:72 onError | 140123308220176(10.10.10.11:55524) RTSP播放器(__defaultVhost__/live/test)断开:rtp over udp session timeouted,耗时(s):48
```
2. 由于没有转码，会出现`unknown codec`的提示，后续想实现PCM转码为AAC，求作者指点：
```
2020-12-26 14:52:16.384 I MediaServer[22867] MediaSource.cpp:394 emitEvent | 媒体注册:hls __defaultVhost__ live test
2020-12-26 14:52:17.742 I MediaServer[22867] MediaSource.cpp:394 emitEvent | 媒体注册:rtsp __defaultVhost__ live test
2020-12-26 14:52:17.865 W MediaServer[22867] Factory.cpp:259 getRtmpCodecByTrack | 暂不支持该CodecId:unknown codec
2020-12-26 14:52:17.865 W MediaServer[22867] TsMuxer.cpp:81 addTrack | mpeg-ts 不支持该编码格式,已忽略:unknown codec
2020-12-26 14:52:17.865 W MediaServer[22867] MP4Muxer.cpp:188 addTrack | MP4录制不支持该编码格式:unknown codec
2020-12-26 14:52:17.865 W MediaServer[22867] TsMuxer.cpp:81 addTrack | mpeg-ts 不支持该编码格式,已忽略:unknown codec
2020-12-26 14:52:21.419 D MediaServer[22867] MediaSink.cpp:123 emitAllTrackReady | all track ready use 5034ms
2020-12-26 14:52:21.419 I MediaServer[22867] MultiMediaSourceMuxer.cpp:281 onAllTrackReady | stream: __defaultVhost__ live test , codec info: unknown codec
```