### PR TITLE
使用URL替换相对路径，避免其余项目的fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ZLToolKit"]
 	path = 3rdpart/ZLToolKit
-	url = ../ZLToolKit
+	url = https://github.com/xia-chu/ZLToolKit
 [submodule "3rdpart/media-server"]
 	path = 3rdpart/media-server
-	url = ../media-server
+	url = https://github.com/xia-chu/media-server

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ZLToolKit"]
 	path = 3rdpart/ZLToolKit
-	url = https://github.com/xia-chu/ZLToolKit
+	url = https://gitee.com/xia-chu/ZLToolKit
 [submodule "3rdpart/media-server"]
 	path = 3rdpart/media-server
-	url = https://github.com/xia-chu/media-server
+	url = https://gitee.com/xia-chu/media-server


### PR DESCRIPTION
项目fork后，还需要将ZLToolKit，media-server两个项目再fork到账号名下，才能够使用git submodule 编译，每次更新同步都很麻烦，建议直接使用URL作为submodule的代码源。